### PR TITLE
Update deprecated code

### DIFF
--- a/paytmchecksum/PaytmChecksum.php
+++ b/paytmchecksum/PaytmChecksum.php
@@ -123,7 +123,7 @@ class PaytmChecksum{
 	}
 
 	static private function pkcs5Unpad($text) {
-		$pad = ord($text{strlen($text) - 1});
+		$pad = ord($text[strlen($text) - 1]);
 		if ($pad > strlen($text))
 			return false;
 		return substr($text, 0, -1 * $pad);


### PR DESCRIPTION
The curly bracket syntax for arrays deprecated [as per this RFC](https://wiki.php.net/rfc/deprecate_curly_braces_array_access) and so using your library throws a warning. It will be removed on PHP 8 rendering this library unusable.