### PR TITLE
Use global Exception class, not namespaced.

### DIFF
--- a/paytmchecksum/PaytmChecksum.php
+++ b/paytmchecksum/PaytmChecksum.php
@@ -63,7 +63,7 @@ class PaytmChecksum{
 
 	static public function verifySignature($params, $key, $checksum){
 		if(!is_array($params) && !is_string($params)){
-			throw new Exception("string or array expected, ".gettype($params)." given");
+			throw new \Exception("string or array expected, ".gettype($params)." given");
 		}
 		if(isset($params['CHECKSUMHASH'])){
 			unset($params['CHECKSUMHASH']);


### PR DESCRIPTION
Using Exception as IS gives the error:
```
<b>Fatal error</b>:  Uncaught Error: Class 'paytm\paytmchecksum\Exception' not found in vendor/paytm/paytmchecksum/paytmchecksum/PaytmChecksum.php:56
```
Because inside a namespace the class tries to refer to it's own package [Reference](https://stackoverflow.com/a/57898948).